### PR TITLE
Update GitHub Actions workflow for PMTiles

### DIFF
--- a/.github/workflows/build-deploy-pmtiles.yml
+++ b/.github/workflows/build-deploy-pmtiles.yml
@@ -1,0 +1,60 @@
+name: Build & Deploy PMTiles
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "config/**"
+      - ".github/workflows/build-and-deploy-pmtiles.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pull Planetiler image
+        run: |
+          docker pull ghcr.io/onthegomap/planetiler:latest
+
+      - name: Build PMTiles with Planetiler
+        run: |
+          mkdir -p out
+          docker run --rm \
+            --memory=4g \
+            -v "$PWD:/data" \
+            ghcr.io/onthegomap/planetiler:latest \
+            --config /data/config/planetiler.yaml \
+            --output /data/out/australia.pmtiles
+
+      - name: Upload PMTiles artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pmtiles
+          path: out/australia.pmtiles
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download PMTiles artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pmtiles
+          path: out/
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.TILESERVER_SSH_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.TILESERVER_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Deploy PMTiles to tileserver
+        run: |
+          rsync -avz --progress \
+            out/australia.pmtiles \
+            ${{ secrets.TILESERVER_USER }}@${{ secrets.TILESERVER_HOST }}:/srv/tiles/


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to **build and deploy PMTiles using Planetiler (Docker)**.

The workflow is intentionally scoped to minimise unnecessary CI load:

* Runs **only on pull requests targeting `main`**
* Triggers **only when Planetiler configuration files change**
* Uses the **official Planetiler Docker image** for reproducible builds
* Outputs a `.pmtiles` file and deploys it to the tileserver on successful runs

This replaces the previously manual and local / JAR-based build process with a consistent, automated pipeline while keeping heavy tile generation out of unrelated PRs.

The narrow trigger scope is deliberate, as Planetiler builds are resource-intensive and should only run when configuration changes would materially affect the resulting tiles.

### TODO

* **Implement a config hash check** to skip PMTiles builds when Planetiler configuration changes do not alter the effective output (e.g. comments, formatting-only changes).
*  Configure with tileserver secrets so that the tiles are uploaded.

This would further reduce unnecessary rebuilds for large, resource-intensive Planetiler runs and improve CI efficiency over time.